### PR TITLE
Can disable scaling and specify letter spacing as font attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.2] - 2021-09-21
+## Changed
+- Support for disabling font scaling either system-wide and/or per-font.
+- Support for custom letter spacing in font styles plist.
+
 ## [4.2.2] - 2020-12-16
 ### Changed
 - Removes a warning relating to iOS 8 being unsupported as a deployment target in Xcode 12 (thanks to @atrinh0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.2] - 2021-09-21
+## [4.3.0] - 2021-09-21
 ## Changed
 - Support for disabling font scaling either system-wide and/or per-font.
 - Support for custom letter spacing in font styles plist.

--- a/TypographyKit.podspec
+++ b/TypographyKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TypographyKit'
-  s.version          = '4.3.2'
+  s.version          = '4.3.0'
   s.summary          = 'Consistent & accessible visual styling on iOS with support for Dynamic Type'
   s.swift_version    = '5.0'
   s.description      = <<-DESC

--- a/TypographyKit.podspec
+++ b/TypographyKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'TypographyKit'
-  s.version          = '4.2.2'
+  s.version          = '4.3.2'
   s.summary          = 'Consistent & accessible visual styling on iOS with support for Dynamic Type'
   s.swift_version    = '5.0'
   s.description      = <<-DESC

--- a/TypographyKit/Classes/ConfigurationKey.swift
+++ b/TypographyKit/Classes/ConfigurationKey.swift
@@ -15,4 +15,5 @@ enum ConfigurationKey: String {
     case pointSize = "point-size"
     case scalingMode = "scaling-mode"
     case textColor = "text-color"
+    case letterSpacing = "letter-spacing"
 }

--- a/TypographyKit/Classes/FontTextStyleParser.swift
+++ b/TypographyKit/Classes/FontTextStyleParser.swift
@@ -98,9 +98,11 @@ private extension FontTextStyleParser {
         if let scalingModeName = fontTextStyle[ConfigurationKey.scalingMode.rawValue] as? String {
             scalingMode = ScalingMode(rawValue: scalingModeName)
         }
+        let letterSpacing = fontTextStyle[ConfigurationKey.letterSpacing.rawValue] as? Double ?? 0
+
         return Typography(name: key, fontName: fontName, fontSize: pointSize, letterCase: letterCase,
-                          maximumPointSize: maxPointSize, minimumPointSize: minPointSize, scalingMode: scalingMode,
-                          textColor: textColor)
+                          letterSpacing: letterSpacing, maximumPointSize: maxPointSize, minimumPointSize: minPointSize,
+                          scalingMode: scalingMode, textColor: textColor)
     }
     
     /// Extends the original Typography style with another style, replacing properties of the

--- a/TypographyKit/Classes/ScalingMode.swift
+++ b/TypographyKit/Classes/ScalingMode.swift
@@ -17,5 +17,8 @@ public enum ScalingMode: String {
     
     /// Point size is scaled with increasing `UIContentSizeCategory` using a step size * multiplier.
     case stepping = "stepping"
+
+    /// Fonts are displayed at the specified size, and accessibility settings are ignored.
+    case disabled = "disabled"
     
 }

--- a/TypographyKit/Classes/Typography.swift
+++ b/TypographyKit/Classes/Typography.swift
@@ -15,6 +15,7 @@ public struct Typography {
     public let minimumPointSize: Float?
     public let pointSize: Float? // base point size for font
     public var letterCase: LetterCase?
+    public var letterSpacing: Double = 0
     public var scalingMode: ScalingMode?
     public var textColor: UIColor?
     private let textStyle: UIFont.TextStyle
@@ -61,21 +62,23 @@ public struct Typography {
         self.minimumPointSize = typographyStyle.minimumPointSize
         self.pointSize = typographyStyle.pointSize
         self.letterCase = typographyStyle.letterCase
+        self.letterSpacing = typographyStyle.letterSpacing
         self.scalingMode = typographyStyle.scalingMode
         self.textColor = typographyStyle.textColor
         self.textStyle = textStyle
     }
     
     public init(name: String, fontName: String? = nil, fontSize: Float? = nil,
-                letterCase: LetterCase? = nil, maximumPointSize: Float? = nil,
-                minimumPointSize: Float? = nil, scalingMode: ScalingMode? = nil,
-                textColor: UIColor? = nil) {
+                letterCase: LetterCase? = nil, letterSpacing: Double = 0,
+                maximumPointSize: Float? = nil, minimumPointSize: Float? = nil,
+                scalingMode: ScalingMode? = nil, textColor: UIColor? = nil) {
         self.name = name
         self.fontName = fontName
         self.maximumPointSize = maximumPointSize
         self.minimumPointSize = minimumPointSize
         self.pointSize = fontSize
         self.letterCase = letterCase
+        self.letterSpacing = letterSpacing
         self.scalingMode = scalingMode
         self.textColor = textColor
         self.textStyle = UIFont.TextStyle(rawValue: name)
@@ -115,6 +118,8 @@ public struct Typography {
             return scaleUsingStepping(fontName, pointSize: pointSize, contentSize: contentSizeCategory)
         case .stepping:
             return scaleUsingStepping(fontName, pointSize: pointSize, contentSize: contentSizeCategory)
+        case .disabled:
+            return font(fontName, pointSize: pointSize)
         }
     }
     

--- a/TypographyKit/Classes/UILabelAdditions.swift
+++ b/TypographyKit/Classes/UILabelAdditions.swift
@@ -114,6 +114,12 @@ extension UILabel {
             let replacementString = replaceTextColor(defaultColor, with: typography.textColor, in: mutableString)
             self.attributedText = replacementString
         }
+        if self.typography.letterSpacing > 0 {
+            guard let attrString = self.attributedText else { return }
+            let spacingString = NSMutableAttributedString(attributedString: attrString)
+            spacingString.addAttribute(.kern, value: self.typography.letterSpacing, range: textRange)
+            self.attributedText = spacingString
+        }
     }
 
     public func text(_ text: String?, style: UIFont.TextStyle, letterCase: LetterCase? = nil,
@@ -130,6 +136,10 @@ extension UILabel {
                 typography.letterCase = letterCase
             }
             self.typography = typography
+
+            if self.typography.letterSpacing > 0 {
+                self.attributedText(NSAttributedString(string: self.text ?? ""), style: style)
+            }
         }
     }
     


### PR DESCRIPTION
    * Added case to ScaleMode enum to optionally disable font scaling.
    * If scale mode is set to .disabled, the requested font is resolved at the size given in the config.
    * Added letter-spacing as typography plist attribute for font styles. Defaults to zero.
    * UILabel.text() checks self.typography.letterSpacing > 0, and if true, converts text to attributed string and calls its attributedText method.