### PR TITLE
Remove SwiftUI modifiers when values are nil

### DIFF
--- a/TypographyKit/Classes/ViewAdditions.swift
+++ b/TypographyKit/Classes/ViewAdditions.swift
@@ -33,10 +33,25 @@ private struct TypographyStyle: ViewModifier {
     
     func body(content: Content) -> some View {
         return content
-            .font(font)
-            .foregroundColor(color)
+            .ifLet(font) { $0.font($1) }
+            .ifLet(color) { $0.foregroundColor($1) }
     }
     
+}
+
+@available(iOS 13, *)
+extension View {
+    @ViewBuilder
+    func ifLet<V, Transform: View>(
+        _ value: V?,
+        transform: (Self, V) -> Transform
+    ) -> some View {
+        if let value = value {
+            transform(self, value)
+        } else {
+            self
+        }
+    }
 }
 
 @available(iOS 13, macCatalyst 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
This fixes an issue where applying a modifier for a typography style with no specified color in TypographyKit will prevent another color `.foregroundColor(.green)` taking effect when chained on a view.

# Example
typography-kit.json 
```
"ui-font-text-styles": {
        "heading": {
            "font-name": "SomeFont",
            "point-size": 30,
            "letter-case": "regular"
        }
}
```
code: 
```
 Text("This text should be green") 
            .typography(style: .heading)
            .foregroundColor(.green)
```


## Existing result: 
Text appears default color
```
 Text("This text should be green") 
            .font(SomeFont)
            .foregroundColor(nil)
            .foregroundColor(.green)
```

## Fixed result: 
Text appears green
```
 Text("This text should be green") 
            .font(SomeFont) 
            .foregroundColor(.green)
```